### PR TITLE
add elantec_touchscreen.idc from tf700 flavour

### DIFF
--- a/idc/elantech_touchscreen.idc
+++ b/idc/elantech_touchscreen.idc
@@ -1,0 +1,29 @@
+# Copyright (C) 2010 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Input Device Configuration File for the Atmel Maxtouch touch screen.
+#
+# These calibration values are derived from empirical measurements
+# and may not be appropriate for use with other touch screens.
+# Refer to the input device configuration documentation for more details.
+#
+
+# Basic Parameters
+touch.deviceType = pointer
+touch.orientationAware = 1
+touch.gestureMode = pointer
+device.external = 1
+touch.usingJitterFilter = 1
+touch.supportElanPalmRejection = 0


### PR DESCRIPTION
This is a pull-request which duplicates my [proposed changeset in gerrit](http://review.cyanogenmod.org/#/c/65566/) since it looks like this repo doesn't use CM's gerrit instance.

A CM11 install on the tf701t will almost work with the touchpad on the
keyboard dock except that, annoyingly, the touchpad is assumed to be an
actual touch screen device and so one ends up with the "circle"-style
mouse pointer.

Copying this file from the tf700 CM configuration results in the
expected "arrow"-style mouse pointer.
